### PR TITLE
'fix' for this zero-distance bug (Issue #87)

### DIFF
--- a/frontend/src/components/sidebar/index.tsx
+++ b/frontend/src/components/sidebar/index.tsx
@@ -92,7 +92,7 @@ export default class Sidebar extends Component<IProps, IState> {
             <Form.Label>Limit the distance inside the graph:</Form.Label>
             <Range
               step={1}
-              min={0}
+              min={1}
               max={5}
               values={this.state.distanceSliderValues}
               onChange={(values: number[]) => this.setState({distanceSliderValues: values})}


### PR DESCRIPTION
Okay, this is just a "fix" because to be honest, a distance of zero doesn't make any sense at all. so the general fix was to make the minimum distance start at 1.
But the actual "error" was here: https://github.com/Jibbow/research-paper-graph/blob/9ccfd2aba66fff50e4ea405dbc4d0916fca5cd1b/frontend/src/pages/PapersPage.tsx#L55

Because `0` is interpreted as `false` and thus it gets replaced by the default value of `3`